### PR TITLE
enable alpheios on the page

### DIFF
--- a/SophAjax_Lloyd-Jones.html
+++ b/SophAjax_Lloyd-Jones.html
@@ -6,7 +6,13 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/alpheios-components@dev-bailly-defs/dist/style/style-components.css"/>
     <link rel="stylesheet" href="css/default.css"/>
     <script src="lib/CETEI.js" charset="utf-8"></script>
-    <script type="text/javascript">
+  
+   <script type="text/javascript">
+     (new CETEI).getHTML5('https://raw.githubusercontent.com/gregorycrane/Wolf1807/master/ajax-2019/ajax-lj.xml', function(data) {
+       document.getElementsByTagName("body")[0].appendChild(data);
+     });
+   </script>
+      <script type="text/javascript">
     document.addEventListener("DOMContentLoaded", function(event) {
       import ("https://cdn.jsdelivr.net/npm/alpheios-embedded@latest/dist/alpheios-embedded.min.js").then(embedLib => {
 
@@ -27,11 +33,6 @@
       })
     });
 
-   </script>
-   <script type="text/javascript">
-     (new CETEI).getHTML5('https://raw.githubusercontent.com/gregorycrane/Wolf1807/master/ajax-2019/ajax-lj.xml', function(data) {
-       document.getElementsByTagName("body")[0].appendChild(data);
-     });
    </script>
     <style>
 

--- a/SophAjax_Lloyd-Jones.html
+++ b/SophAjax_Lloyd-Jones.html
@@ -39,7 +39,7 @@
     </style>
     <title>Sophocles Ajax (ed. Lloyd-Jones)</title>
   </head>
-  <body>
+  <body class="alpheios-enabled" lang="grc">
     <h1>Sophocles <i>Ajax</i>, ed. Lloyd-Jones (Oxford, 1994)</h1>
     <p>The TEI/XML edition of the critical text established by Lloyd-Jones displayed below was created by Gregory Crane, and is dynamically pulled from <a href="https://raw.githubusercontent.com/gregorycrane/Wolf1807/master/ajax-2019/ajax-lj.xml">GitHub</a>.</p>
   </body>

--- a/SophAjax_Lloyd-Jones.html
+++ b/SophAjax_Lloyd-Jones.html
@@ -40,7 +40,7 @@
     <title>Sophocles Ajax (ed. Lloyd-Jones)</title>
   </head>
   <body class="alpheios-enabled" lang="grc">
-    <h1>Sophocles <i>Ajax</i>, ed. Lloyd-Jones (Oxford, 1994)</h1>
-    <p>The TEI/XML edition of the critical text established by Lloyd-Jones displayed below was created by Gregory Crane, and is dynamically pulled from <a href="https://raw.githubusercontent.com/gregorycrane/Wolf1807/master/ajax-2019/ajax-lj.xml">GitHub</a>.</p>
+    <h1 data-alpheios-ignore="all">Sophocles <i>Ajax</i>, ed. Lloyd-Jones (Oxford, 1994)</h1>
+    <p data-alpheios-ignore="all">The TEI/XML edition of the critical text established by Lloyd-Jones displayed below was created by Gregory Crane, and is dynamically pulled from <a href="https://raw.githubusercontent.com/gregorycrane/Wolf1807/master/ajax-2019/ajax-lj.xml">GitHub</a>.</p>
   </body>
 </html>


### PR DESCRIPTION
Matteo, you need to add the `class="alpheios-enabled"` and `lang="grc"` attributes to the parent element that contains text for lookup. For now I put it on the body and added `data-alpheios-ignore="all"` to the header lines so that they aren't enabled.

You could be more granular if you have access to the XSL of ceteicean but this is probably good enough for now.

(I also moved the Alpheios script activation to after ceteicean but that probably is only necessary if you are going to add the alpheios-enabled class in the ceteicean transform.)
